### PR TITLE
Remove Wowza Load Test Tool support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,12 +151,6 @@ wowza_mediacache_enable: no
 # Production or Development or custom size e.g. 8000M
 wowza_tuning_heapsize: Development
 
-# WARNING!!! Wowza Load Testing Tool disables Wowza Streaming Engine Manager.
-# Do not use Wowza Load Testing Tool on production streaming servers!
-# You need WowzaStreamingEngineLoadTestTool.jar file from separate package:
-# https://www.wowza.com/docs/test-wowza-streaming-engine-media-server-streaming-load
-wowza_loadtesttool_enable: no
-
 # Wowza modules
 wowza_modules_collection_url: 'https://www.wowza.com/downloads/forums/collection'
 wowza_modules_streampublisher_enable: no

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -136,12 +136,6 @@ wowza_mediacache_enable: no
 # Production or Development or custom size e.g. 8000M
 wowza_tuning_heapsize: Development
 
-# WARNING!!! Wowza Load Testing Tool disables Wowza Streaming Engine Manager.
-# Do not use Wowza Load Testing Tool on production streaming servers!
-# You need WowzaStreamingEngineLoadTestTool.jar file from separate package:
-# https://www.wowza.com/docs/test-wowza-streaming-engine-media-server-streaming-load
-wowza_loadtesttool_enable: no
-
 # Wowza modules
 wowza_modules_collection_url: 'https://www.wowza.com/downloads/forums/collection'
 wowza_modules_streampublisher_enable: no

--- a/templates/Server.xml.j2
+++ b/templates/Server.xml.j2
@@ -63,11 +63,6 @@
 			<DefaultStreamPrefix>mp4</DefaultStreamPrefix>
 		</Streams>
 		<ServerListeners>
-{% if wowza_loadtesttool_enable %}
-			<ServerListener>
-				<BaseClass>com.wowza.wse.loadtest.server.ServerManager</BaseClass>
-			</ServerListener>
-{% endif  %}
 {% if wowza_mediacache_enable %}
 			<ServerListener>
 				<BaseClass>com.wowza.wms.mediacache.impl.MediaCacheServerListener</BaseClass>
@@ -113,17 +108,6 @@
 		</Transcoder>
 		<!-- Properties defined here will be added to the IServer.getProperties() collection -->
 		<Properties>
-{% if wowza_loadtesttool_enable %}
-			<Property>
-				<Name>loadTest_authentication</Name>
-				<Value>none</Value>
-			</Property>
-			<Property>
-				<Name>loadTest_forceMaxProtocolClient</Name>
-				<Value>5000</Value>
-				<Type>Integer</Type>
-			</Property>
-{% endif  %}
 		</Properties>
 	</Server>
 </Root>


### PR DESCRIPTION
Remove Wowza Load Test Tool support. Wowza recommends Apache JMeter:
https://www.wowza.com/docs/load-test-a-wowza-streaming-engine-server